### PR TITLE
Feature/hipchat router

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git*
+.ms-mock*

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .ms-mock/*
+.env
+.releases/meet*
+*cover.out*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM prom/busybox
 MAINTAINER DavyJ0nes <davy.jones@me.com>
 ENV UPDATED_ON 28-01-2017
+ENV MEETSPACEBOT_TEST false
 
 RUN mkdir -p /srv/app
 WORKDIR /srv/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
-FROM golang:1.7-onbuild
-MAINTAINER davyj0nes <davy.jones@me.com>
-ENV UPDATED_ON: 28-01-2017
+FROM prom/busybox
+MAINTAINER DavyJ0nes <davy.jones@me.com>
+ENV UPDATED_ON 28-01-2017
+
+RUN mkdir -p /srv/app
+WORKDIR /srv/app
+ADD releases/meetspaceBot /srv/app
+EXPOSE 8081
+CMD ["./meetspaceBot"]
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,338 @@
+Copyright (c) 2017 The meetspacebot AUTHORS. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+	 * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+	 * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+----------
+
+Some documentation is taken from the GitHub Developer site
+<http://developer.github.com/>, which is available under the following Creative
+Commons Attribution 3.0 License.  This applies only to the go-github source
+code and would not apply to any compiled binaries.
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE
+COMMONS PUBLIC LICENSE ("CCPL" OR "LICENSE"). THE WORK IS PROTECTED BY
+COPYRIGHT AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS
+AUTHORIZED UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. TO THE EXTENT THIS LICENSE MAY
+BE CONSIDERED TO BE A CONTRACT, THE LICENSOR GRANTS YOU THE RIGHTS
+CONTAINED HERE IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS.
+
+1. Definitions
+
+ a. "Adaptation" means a work based upon the Work, or upon the Work and
+		other pre-existing works, such as a translation, adaptation,
+		derivative work, arrangement of music or other alterations of a
+		literary or artistic work, or phonogram or performance and includes
+		cinematographic adaptations or any other form in which the Work may be
+		recast, transformed, or adapted including in any form recognizably
+		derived from the original, except that a work that constitutes a
+		Collection will not be considered an Adaptation for the purpose of
+		this License. For the avoidance of doubt, where the Work is a musical
+		work, performance or phonogram, the synchronization of the Work in
+		timed-relation with a moving image ("synching") will be considered an
+		Adaptation for the purpose of this License.
+ b. "Collection" means a collection of literary or artistic works, such as
+		encyclopedias and anthologies, or performances, phonograms or
+		broadcasts, or other works or subject matter other than works listed
+		in Section 1(f) below, which, by reason of the selection and
+		arrangement of their contents, constitute intellectual creations, in
+		which the Work is included in its entirety in unmodified form along
+		with one or more other contributions, each constituting separate and
+		independent works in themselves, which together are assembled into a
+		collective whole. A work that constitutes a Collection will not be
+		considered an Adaptation (as defined above) for the purposes of this
+		License.
+ c. "Distribute" means to make available to the public the original and
+		copies of the Work or Adaptation, as appropriate, through sale or
+		other transfer of ownership.
+ d. "Licensor" means the individual, individuals, entity or entities that
+		offer(s) the Work under the terms of this License.
+ e. "Original Author" means, in the case of a literary or artistic work,
+		the individual, individuals, entity or entities who created the Work
+		or if no individual or entity can be identified, the publisher; and in
+		addition (i) in the case of a performance the actors, singers,
+		musicians, dancers, and other persons who act, sing, deliver, declaim,
+		play in, interpret or otherwise perform literary or artistic works or
+		expressions of folklore; (ii) in the case of a phonogram the producer
+		being the person or legal entity who first fixes the sounds of a
+		performance or other sounds; and, (iii) in the case of broadcasts, the
+		organization that transmits the broadcast.
+ f. "Work" means the literary and/or artistic work offered under the terms
+		of this License including without limitation any production in the
+		literary, scientific and artistic domain, whatever may be the mode or
+		form of its expression including digital form, such as a book,
+		pamphlet and other writing; a lecture, address, sermon or other work
+		of the same nature; a dramatic or dramatico-musical work; a
+		choreographic work or entertainment in dumb show; a musical
+		composition with or without words; a cinematographic work to which are
+		assimilated works expressed by a process analogous to cinematography;
+		a work of drawing, painting, architecture, sculpture, engraving or
+		lithography; a photographic work to which are assimilated works
+		expressed by a process analogous to photography; a work of applied
+		art; an illustration, map, plan, sketch or three-dimensional work
+		relative to geography, topography, architecture or science; a
+		performance; a broadcast; a phonogram; a compilation of data to the
+		extent it is protected as a copyrightable work; or a work performed by
+		a variety or circus performer to the extent it is not otherwise
+		considered a literary or artistic work.
+ g. "You" means an individual or entity exercising rights under this
+		License who has not previously violated the terms of this License with
+		respect to the Work, or who has received express permission from the
+		Licensor to exercise rights under this License despite a previous
+		violation.
+ h. "Publicly Perform" means to perform public recitations of the Work and
+		to communicate to the public those public recitations, by any means or
+		process, including by wire or wireless means or public digital
+		performances; to make available to the public Works in such a way that
+		members of the public may access these Works from a place and at a
+		place individually chosen by them; to perform the Work to the public
+		by any means or process and the communication to the public of the
+		performances of the Work, including by public digital performance; to
+		broadcast and rebroadcast the Work by any means including signs,
+		sounds or images.
+ i. "Reproduce" means to make copies of the Work by any means including
+		without limitation by sound or visual recordings and the right of
+		fixation and reproducing fixations of the Work, including storage of a
+		protected performance or phonogram in digital form or other electronic
+		medium.
+
+2. Fair Dealing Rights. Nothing in this License is intended to reduce,
+limit, or restrict any uses free from copyright or rights arising from
+limitations or exceptions that are provided for in connection with the
+copyright protection under copyright law or other applicable laws.
+
+3. License Grant. Subject to the terms and conditions of this License,
+Licensor hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license to
+exercise the rights in the Work as stated below:
+
+ a. to Reproduce the Work, to incorporate the Work into one or more
+		Collections, and to Reproduce the Work as incorporated in the
+		Collections;
+ b. to create and Reproduce Adaptations provided that any such Adaptation,
+		including any translation in any medium, takes reasonable steps to
+		clearly label, demarcate or otherwise identify that changes were made
+		to the original Work. For example, a translation could be marked "The
+		original work was translated from English to Spanish," or a
+		modification could indicate "The original work has been modified.";
+ c. to Distribute and Publicly Perform the Work including as incorporated
+		in Collections; and,
+ d. to Distribute and Publicly Perform Adaptations.
+ e. For the avoidance of doubt:
+
+		 i. Non-waivable Compulsory License Schemes. In those jurisdictions in
+				which the right to collect royalties through any statutory or
+				compulsory licensing scheme cannot be waived, the Licensor
+				reserves the exclusive right to collect such royalties for any
+				exercise by You of the rights granted under this License;
+		ii. Waivable Compulsory License Schemes. In those jurisdictions in
+				which the right to collect royalties through any statutory or
+				compulsory licensing scheme can be waived, the Licensor waives the
+				exclusive right to collect such royalties for any exercise by You
+				of the rights granted under this License; and,
+	 iii. Voluntary License Schemes. The Licensor waives the right to
+				collect royalties, whether individually or, in the event that the
+				Licensor is a member of a collecting society that administers
+				voluntary licensing schemes, via that society, from any exercise
+				by You of the rights granted under this License.
+
+The above rights may be exercised in all media and formats whether now
+known or hereafter devised. The above rights include the right to make
+such modifications as are technically necessary to exercise the rights in
+other media and formats. Subject to Section 8(f), all rights not expressly
+granted by Licensor are hereby reserved.
+
+4. Restrictions. The license granted in Section 3 above is expressly made
+subject to and limited by the following restrictions:
+
+ a. You may Distribute or Publicly Perform the Work only under the terms
+		of this License. You must include a copy of, or the Uniform Resource
+		Identifier (URI) for, this License with every copy of the Work You
+		Distribute or Publicly Perform. You may not offer or impose any terms
+		on the Work that restrict the terms of this License or the ability of
+		the recipient of the Work to exercise the rights granted to that
+		recipient under the terms of the License. You may not sublicense the
+		Work. You must keep intact all notices that refer to this License and
+		to the disclaimer of warranties with every copy of the Work You
+		Distribute or Publicly Perform. When You Distribute or Publicly
+		Perform the Work, You may not impose any effective technological
+		measures on the Work that restrict the ability of a recipient of the
+		Work from You to exercise the rights granted to that recipient under
+		the terms of the License. This Section 4(a) applies to the Work as
+		incorporated in a Collection, but this does not require the Collection
+		apart from the Work itself to be made subject to the terms of this
+		License. If You create a Collection, upon notice from any Licensor You
+		must, to the extent practicable, remove from the Collection any credit
+		as required by Section 4(b), as requested. If You create an
+		Adaptation, upon notice from any Licensor You must, to the extent
+		practicable, remove from the Adaptation any credit as required by
+		Section 4(b), as requested.
+ b. If You Distribute, or Publicly Perform the Work or any Adaptations or
+		Collections, You must, unless a request has been made pursuant to
+		Section 4(a), keep intact all copyright notices for the Work and
+		provide, reasonable to the medium or means You are utilizing: (i) the
+		name of the Original Author (or pseudonym, if applicable) if supplied,
+		and/or if the Original Author and/or Licensor designate another party
+		or parties (e.g., a sponsor institute, publishing entity, journal) for
+		attribution ("Attribution Parties") in Licensor's copyright notice,
+		terms of service or by other reasonable means, the name of such party
+		or parties; (ii) the title of the Work if supplied; (iii) to the
+		extent reasonably practicable, the URI, if any, that Licensor
+		specifies to be associated with the Work, unless such URI does not
+		refer to the copyright notice or licensing information for the Work;
+		and (iv) , consistent with Section 3(b), in the case of an Adaptation,
+		a credit identifying the use of the Work in the Adaptation (e.g.,
+		"French translation of the Work by Original Author," or "Screenplay
+		based on original Work by Original Author"). The credit required by
+		this Section 4 (b) may be implemented in any reasonable manner;
+		provided, however, that in the case of a Adaptation or Collection, at
+		a minimum such credit will appear, if a credit for all contributing
+		authors of the Adaptation or Collection appears, then as part of these
+		credits and in a manner at least as prominent as the credits for the
+		other contributing authors. For the avoidance of doubt, You may only
+		use the credit required by this Section for the purpose of attribution
+		in the manner set out above and, by exercising Your rights under this
+		License, You may not implicitly or explicitly assert or imply any
+		connection with, sponsorship or endorsement by the Original Author,
+		Licensor and/or Attribution Parties, as appropriate, of You or Your
+		use of the Work, without the separate, express prior written
+		permission of the Original Author, Licensor and/or Attribution
+		Parties.
+ c. Except as otherwise agreed in writing by the Licensor or as may be
+		otherwise permitted by applicable law, if You Reproduce, Distribute or
+		Publicly Perform the Work either by itself or as part of any
+		Adaptations or Collections, You must not distort, mutilate, modify or
+		take other derogatory action in relation to the Work which would be
+		prejudicial to the Original Author's honor or reputation. Licensor
+		agrees that in those jurisdictions (e.g. Japan), in which any exercise
+		of the right granted in Section 3(b) of this License (the right to
+		make Adaptations) would be deemed to be a distortion, mutilation,
+		modification or other derogatory action prejudicial to the Original
+		Author's honor and reputation, the Licensor will waive or not assert,
+		as appropriate, this Section, to the fullest extent permitted by the
+		applicable national law, to enable You to reasonably exercise Your
+		right under Section 3(b) of this License (right to make Adaptations)
+		but not otherwise.
+
+5. Representations, Warranties and Disclaimer
+
+UNLESS OTHERWISE MUTUALLY AGREED TO BY THE PARTIES IN WRITING, LICENSOR
+OFFERS THE WORK AS-IS AND MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY
+KIND CONCERNING THE WORK, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE,
+INCLUDING, WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY,
+FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, OR THE ABSENCE OF
+LATENT OR OTHER DEFECTS, ACCURACY, OR THE PRESENCE OF ABSENCE OF ERRORS,
+WHETHER OR NOT DISCOVERABLE. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION
+OF IMPLIED WARRANTIES, SO SUCH EXCLUSION MAY NOT APPLY TO YOU.
+
+6. Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE
+LAW, IN NO EVENT WILL LICENSOR BE LIABLE TO YOU ON ANY LEGAL THEORY FOR
+ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY DAMAGES
+ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK, EVEN IF LICENSOR HAS
+BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+7. Termination
+
+ a. This License and the rights granted hereunder will terminate
+		automatically upon any breach by You of the terms of this License.
+		Individuals or entities who have received Adaptations or Collections
+		from You under this License, however, will not have their licenses
+		terminated provided such individuals or entities remain in full
+		compliance with those licenses. Sections 1, 2, 5, 6, 7, and 8 will
+		survive any termination of this License.
+ b. Subject to the above terms and conditions, the license granted here is
+		perpetual (for the duration of the applicable copyright in the Work).
+		Notwithstanding the above, Licensor reserves the right to release the
+		Work under different license terms or to stop distributing the Work at
+		any time; provided, however that any such election will not serve to
+		withdraw this License (or any other license that has been, or is
+		required to be, granted under the terms of this License), and this
+		License will continue in full force and effect unless terminated as
+		stated above.
+
+8. Miscellaneous
+
+ a. Each time You Distribute or Publicly Perform the Work or a Collection,
+		the Licensor offers to the recipient a license to the Work on the same
+		terms and conditions as the license granted to You under this License.
+ b. Each time You Distribute or Publicly Perform an Adaptation, Licensor
+		offers to the recipient a license to the original Work on the same
+		terms and conditions as the license granted to You under this License.
+ c. If any provision of this License is invalid or unenforceable under
+		applicable law, it shall not affect the validity or enforceability of
+		the remainder of the terms of this License, and without further action
+		by the parties to this agreement, such provision shall be reformed to
+		the minimum extent necessary to make such provision valid and
+		enforceable.
+ d. No term or provision of this License shall be deemed waived and no
+		breach consented to unless such waiver or consent shall be in writing
+		and signed by the party to be charged with such waiver or consent.
+ e. This License constitutes the entire agreement between the parties with
+		respect to the Work licensed here. There are no understandings,
+		agreements or representations with respect to the Work not specified
+		here. Licensor shall not be bound by any additional provisions that
+		may appear in any communication from You. This License may not be
+		modified without the mutual written agreement of the Licensor and You.
+ f. The rights granted under, and the subject matter referenced, in this
+		License were drafted utilizing the terminology of the Berne Convention
+		for the Protection of Literary and Artistic Works (as amended on
+		September 28, 1979), the Rome Convention of 1961, the WIPO Copyright
+		Treaty of 1996, the WIPO Performances and Phonograms Treaty of 1996
+		and the Universal Copyright Convention (as revised on July 24, 1971).
+		These rights and subject matter take effect in the relevant
+		jurisdiction in which the License terms are sought to be enforced
+		according to the corresponding provisions of the implementation of
+		those treaty provisions in the applicable national law. If the
+		standard suite of rights granted under applicable copyright law
+		includes additional rights not granted under this License, such
+		additional rights are deemed to be included in the License; this
+		License is not intended to restrict the license of any rights under
+		applicable law.
+
+
+Creative Commons Notice
+
+		Creative Commons is not a party to this License, and makes no warranty
+		whatsoever in connection with the Work. Creative Commons will not be
+		liable to You or any party on any legal theory for any damages
+		whatsoever, including without limitation any general, special,
+		incidental or consequential damages arising in connection to this
+		license. Notwithstanding the foregoing two (2) sentences, if Creative
+		Commons has expressly identified itself as the Licensor hereunder, it
+		shall have all rights and obligations of Licensor.
+
+		Except for the limited purpose of indicating to the public that the
+		Work is licensed under the CCPL, Creative Commons does not authorize
+		the use by either party of the trademark "Creative Commons" or any
+		related trademark or logo of Creative Commons without the prior
+		written consent of Creative Commons. Any permitted use will be in
+		compliance with Creative Commons' then-current trademark usage
+		guidelines, as may be published on its website or otherwise made
+		available upon request from time to time. For the avoidance of doubt,
+		this trademark restriction does not form part of this License.
+
+		Creative Commons may be contacted at http://creativecommons.org/.

--- a/README.md
+++ b/README.md
@@ -6,3 +6,42 @@
 /_/ /_/ /_/\___/\___/\__/____/ .___/\__,_/\___/\___/_____/\____/\__/  
                             /_/                                       
 ```
+
+# Overview
+This is a simple bot that links [Hipchat](https://www.hipchat.com/) with  [Meetspace](http://www.meetspaceapp.com) Video chat
+
+The deployment artifact is a GO binary that is run from a docker container. To help keep the container size to a minimum I'm using a static binary by [disabling cgo](https://golang.org/cmd/cgo/) and rebuilding all dependencies as well with cgo disabled. I would have used "FROM scratch" but needed environment variables. [More Infomation](https://blog.codeship.com/building-minimal-docker-containers-for-go-applications/)
+
+If you want to run it outside of Docker, then within [Releases](./releases) there is the latest stable go binary that is compiled to run on Linux.
+
+# Usage
+
+## Run in Docker
+You can run in Docker with:
+```
+docker run -p 80:8081 -d --name msb-1 -e HIPCHAT_API_TOKEN="" -e MEETSPACE_API_TOKEN="" davyj0nes/meetspacebot"
+```
+There is also a helper script for running on remote machine. For testing I am just using a basic AWS EC2 instance with Docker installed.
+
+## How to deploy with script
+1. Declare Environment variables or change in deploy script
+2. Run `./deploy deploy`
+
+## Set up in Hipchat
+Please follow this guide: https://blog.hipchat.com/2015/02/11/build-your-own-integration-with-hipchat/
+- For the Slash command, it needs to be set as "/meetspace"
+- For the url, it needs to follow this schema: "<host>/api/v0/hipchat"
+
+# Use of Environment Variables
+The Bot requires the following environment variables to be set:
+- `HIPCHAT_API_TOKEN` - This is the Hipchat API token. You can generate one from [here](https://www.hipchat.com/account/api) 
+- `MEETSPACE_API_TOKEN` - This is the API token for meetspace.
+
+# Roadmap
+This package was made for personal use but would like to add the following in the future. 
+Any contributions are welcome - Just open a PR.
+- Slack Support
+- Deeper integration with HipChat
+
+# License
+This package is distributed under the BSD-style license found in the [LICENSE](./LICENSE) file.

--- a/deploy
+++ b/deploy
@@ -1,0 +1,73 @@
+#!/bin/zsh
+# This is a real basic deployment script
+autoload -U colors && colors
+dockerHost=$DOCKERPROD
+hipchat_token=$HIPCHAT_API_TOKEN
+
+echo "$fg[blue]"
+
+case "$1" in
+  status)
+    ssh $dockerHost "sudo docker ps -a"
+    echo "$fg[none]"
+    exit 0
+    ;;
+  log|logs)
+    ssh $dockerHost "sudo docker logs -f msb-1"
+    echo "$fg[none]"
+    exit 0
+    ;;
+  start)
+    ssh $dockerHost "sudo docker start msb-1"
+    ssh $dockerHost "sudo docker ps -a"
+    echo "$fg[none]"
+    exit 0
+    ;;
+  clean)
+    d_list=$(ssh $dockerHost "sudo docker ps -aq")
+    i_list=$(ssh $dockerHost "sudo docker images -aq")
+    ssh $dockerHost "sudo docker kill $d_list"
+    ssh $dockerHost "sudo docker rm $d_list"
+    ssh $dockerHost " sudo docker rmi $i_list"
+    ;;
+  deploy)
+    CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o releases/meetspaceBot .
+    if [ $? != 0 ]; then
+      echo "$fg[red] !! Failed to build"
+      echo "$fg[none]"
+      exit 1
+    fi
+    docker build -q --no-cache -t meetspacebot .
+    imageID=$(docker images -q meetspacebot:latest)
+    docker tag $imageID davyj0nes/meetspacebot:latest
+    docker push davyj0nes/meetspacebot
+
+    running=$(ssh $dockerHost "sudo docker ps -q -f name=msb-1")
+    if [ "$running" != "" ]; then
+      echo "$fg[red]## Container Running ##"
+      echo "$fg[red]...Removing..."
+      ssh $dockerHost "sudo docker kill msb-1 && sudo docker rm msb-1"
+      echo "$fg[green]Container Removed"
+      ssh $dockerHost "sudo docker ps"
+    fi
+  
+    echo "$fg[yellow]## Starting Container"
+    ssh $dockerHost "sudo docker pull davyj0nes/meetspacebot && \
+      sudo docker run -p 80:8081 -d --name msb-1 -e HIPCHAT_API_TOKEN="$hipchat_token" davyj0nes/meetspacebot"
+    echo "## Container Running"
+    ssh $dockerHost "sudo docker ps -a"
+    echo "$fg[none]"
+    exit 0
+    ;;
+  *)
+    echo "$fg[red] Unknown Command"
+    echo "$fg[yellow] Usage:"
+    echo "$fg[yellow]   deploy <command>"
+    echo "$fg[yellow]   - status [Show docker ps]"
+    echo "$fg[yellow]   - log    [Follow logs of container]"
+    echo "$fg[yellow]   - deploy [Deploy new version to prod]"
+    echo "$fg[yellow]   - clean  [Tidy up containers]"
+    echo "$fg[none]"
+    exit 1
+    ;;
+esac

--- a/deploy
+++ b/deploy
@@ -1,8 +1,13 @@
 #!/bin/zsh
 # This is a real basic deployment script
 autoload -U colors && colors
+#
+### Set these variables
 dockerHost=$DOCKERPROD
 hipchat_token=$HIPCHAT_API_TOKEN
+meetspace_token=$MEETSPACE_API_TOKEN
+ms_teamname=$MEETSPACEBOT_TEAM
+###
 
 echo "$fg[blue]"
 
@@ -31,15 +36,21 @@ case "$1" in
     ssh $dockerHost " sudo docker rmi $i_list"
     ;;
   deploy)
+    echo "$fg[yellow] # Starting Compile #"
     CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o releases/meetspaceBot .
     if [ $? != 0 ]; then
       echo "$fg[red] !! Failed to build"
       echo "$fg[none]"
       exit 1
     fi
+    echo "$fg[yellow] # Compile Finished #"
+    echo "$fg[yellow] ##  Starting Container Build ##"
+    echo "$fg[blue]"
     docker build -q --no-cache -t meetspacebot .
     imageID=$(docker images -q meetspacebot:latest)
     docker tag $imageID davyj0nes/meetspacebot:latest
+    echo "$fg[yellow] ###  Pushing Container to Registry ###"
+    echo "$fg[blue]"
     docker push davyj0nes/meetspacebot
 
     running=$(ssh $dockerHost "sudo docker ps -q -f name=msb-1")
@@ -51,9 +62,10 @@ case "$1" in
       ssh $dockerHost "sudo docker ps"
     fi
   
-    echo "$fg[yellow]## Starting Container"
+    echo "$fg[yellow]### Starting Container ####" 
+    echo "$fg[blue]"
     ssh $dockerHost "sudo docker pull davyj0nes/meetspacebot && \
-      sudo docker run -p 80:8081 -d --name msb-1 -e HIPCHAT_API_TOKEN="$hipchat_token" davyj0nes/meetspacebot"
+      sudo docker run --restart=unless-stopped -p 80:8081 -d --name msb-1 -e HIPCHAT_API_TOKEN="$hipchat_token" -e MEETSPACE_API_TOKEN="$meetspace_token" -e MEETSPACEBOT_TEAM="$ms_teamname" davyj0nes/meetspacebot"
     echo "## Container Running"
     ssh $dockerHost "sudo docker ps -a"
     echo "$fg[none]"

--- a/env.example
+++ b/env.example
@@ -1,3 +1,5 @@
 export MEETSPACE_API_TOKEN="123456789"
 export HIPCHAT_API_TOKEN="abcdefghijklmnopqrstuvwxyz"
 export DOCKERPROD="sshstuff"
+export MEETSPACEBOT_TEST="false"
+export MEETSPACEBOT_TEAM="teamname"

--- a/env.example
+++ b/env.example
@@ -1,0 +1,3 @@
+export MEETSPACE_API_TOKEN="123456789"
+export HIPCHAT_API_TOKEN="abcdefghijklmnopqrstuvwxyz"
+export DOCKERPROD="sshstuff"

--- a/hipchatAPI/hipchatAPI.go
+++ b/hipchatAPI/hipchatAPI.go
@@ -2,63 +2,45 @@ package hipchatAPI
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/tbruyelle/hipchat-go/hipchat"
 )
 
-// example POST message
-// {
-// "event": "room_message",
-// "item": {
-//   "message": {
-//     "date": "2017-01-28T18:56:22.407746+00:00",
-//     "from": {
-//       "id": 3709716,
-//       "links": {
-//         "self": "https://api.hipchat.com/v2/user/3709716"
-//       },
-//       "mention_name": "davy",
-//       "name": "Davy Jones",
-//       "version": "T6JP69OQ"
-//     },
-//     "id": "d6ebec9f-1fa5-4e65-8f2b-54745150b718",
-//     "mentions": [],
-//     "message": "/meetspace",
-//     "type": "message"
-//   },
-//   "room": {
-//     "id": 3143303,
-//     "is_archived": false,
-//     "links": {
-//       "members": "https://api.hipchat.com/v2/room/3143303/member",
-//       "participants": "https://api.hipchat.com/v2/room/3143303/participant",
-//       "self": "https://api.hipchat.com/v2/room/3143303",
-//       "webhooks": "https://api.hipchat.com/v2/room/3143303/webhook"
-//     },
-//     "name": "hw",
-//     "privacy": "private",
-//     "version": "RLICVYSR"
-//   }
-// },
-// "oauth_client_id": "1b9f9174-a01f-40d1-9e4b-415e405c5b5b",
-// "webhook_id": 16080298
-// }
-
 // HipchatPostData is a struct for the data that is sent
 //   When the slash command is triggered
-// Only need Room Name from the POST request
 type HipchatPostData struct {
 	Event string `json:"event"`
 	Item  item   `json:"item"`
 }
 
 type item struct {
-	Room room `json:"room"`
+	Message message `json:"message"`
+	Room    struct {
+		Name string `json:"name"`
+	} `json:"room"`
 }
 
-type room struct {
-	Name string `json:"name"`
+type message struct {
+	From    from   `json:"from"`
+	Message string `json:"message"`
+}
+
+type from struct {
+	MentionName string `json:"mention_name"`
+	Name        string `json:"name"`
+}
+
+type HipChatAPIError struct {
+	Error struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Type    string `json:"type"`
+	} `json:"error"`
 }
 
 // ParsedHipchatReq simply parses the POST Req JSON into something useful
@@ -72,13 +54,74 @@ func ParseHipchatReq(data []byte) (HipchatPostData, error) {
 }
 
 // HipchatNotification sends Room Notification Message
-func HipchatNotification() error {
-	hc_auth := os.Getenv("HIPCHAT_API_TOKEN")
-	c := hipchat.NewClient(hc_auth)
-	notifMsg := &hipchat.NotificationRequest{Message: "Testing"}
-	_, err := c.Room.Notification("hw", notifMsg)
-	if err != nil {
-		return err
+// The notification is chosen based on user input
+func HipchatNotification(hc HipchatPostData, test string) (string, error) {
+	var notifReq *hipchat.NotificationRequest
+	c := hipchat.NewClient(os.Getenv("HIPCHAT_API_TOKEN"))
+	commandMessage := hc.Item.Message.Message
+	roomName := hc.Item.Room.Name
+	msTeam := os.Getenv("MEETSPACEBOT_TEAM")
+
+	// Will add more commands in future
+	// To be changed to not be hard coded
+	switch commandMessage {
+	case "/meetspace core":
+		notifReq = statusMessage(roomName, msTeam, "core")
+	case "/meetspace dev":
+		notifReq = statusMessage(roomName, msTeam, "dev")
+	default:
+		notifReq = helpMessage(roomName)
 	}
-	return nil
+
+	// Unelegant way to test at the moment
+	// Is set by environment variable
+	if test == "true" {
+		return notifReq.Message, nil
+	}
+
+	// This does not get covered in tests
+	//  Need to find a way to mock this out
+	res, err := c.Room.Notification(roomName, notifReq)
+	// This is messy but error was returning with other implementations
+	if res.StatusCode != 200 {
+		if res.StatusCode != 204 {
+			resMessage := HipChatAPIError{}
+			resBody, _ := ioutil.ReadAll(res.Body)
+			json.Unmarshal(resBody, &resMessage)
+			return "", errors.New(fmt.Sprintf("%v - \n%s\n\n%s", res.StatusCode, resMessage.Error.Message, resMessage.Error.Type))
+		}
+	}
+	if err != nil {
+		return "", err
+	}
+
+	return "", errors.New("End of function, should not get here")
+}
+
+// statusMessage is called when router sees /meetspace status
+func statusMessage(room, team, slug string) *hipchat.NotificationRequest {
+	meetspaceURL := fmt.Sprintf("https://meetspaceapp.com/%s/%s", team, slug)
+
+	// This is here as reminder that I need to get sending Cards working
+	msgCard := &hipchat.Card{
+		Style: "link",
+		URL:   meetspaceURL,
+		Title: "Click here to join call",
+		Description: hipchat.CardDescription{
+			Format: "format",
+			Value:  "value",
+		},
+	}
+	msgBody := fmt.Sprintf(`%s <a href="%s">%s %s Team</a>`, msgCard.Title, msgCard.URL, strings.Title(team), strings.Title(slug))
+	return &hipchat.NotificationRequest{From: "Meetspace Bot", Message: msgBody, Color: "purple"}
+
+	// Need to fix request for sending Card to work. More work needed
+	// return &hipchat.NotificationRequest{Message: msgBody, Card: msgCard}
+}
+
+// helpMessage is called when any other command is given
+func helpMessage(room string) *hipchat.NotificationRequest {
+	msgBody := fmt.Sprintf("<p><strong>Usage:</strong><br><code>/meetspace core # start core team call</code><br><code>/meetspace dev  # start dev team call</code></p>")
+
+	return &hipchat.NotificationRequest{From: "Meetspace Bot", Message: msgBody, Color: "gray"}
 }

--- a/hipchatAPI/hipchatAPI.go
+++ b/hipchatAPI/hipchatAPI.go
@@ -1,0 +1,84 @@
+package hipchatAPI
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/tbruyelle/hipchat-go/hipchat"
+)
+
+// example POST message
+// {
+// "event": "room_message",
+// "item": {
+//   "message": {
+//     "date": "2017-01-28T18:56:22.407746+00:00",
+//     "from": {
+//       "id": 3709716,
+//       "links": {
+//         "self": "https://api.hipchat.com/v2/user/3709716"
+//       },
+//       "mention_name": "davy",
+//       "name": "Davy Jones",
+//       "version": "T6JP69OQ"
+//     },
+//     "id": "d6ebec9f-1fa5-4e65-8f2b-54745150b718",
+//     "mentions": [],
+//     "message": "/meetspace",
+//     "type": "message"
+//   },
+//   "room": {
+//     "id": 3143303,
+//     "is_archived": false,
+//     "links": {
+//       "members": "https://api.hipchat.com/v2/room/3143303/member",
+//       "participants": "https://api.hipchat.com/v2/room/3143303/participant",
+//       "self": "https://api.hipchat.com/v2/room/3143303",
+//       "webhooks": "https://api.hipchat.com/v2/room/3143303/webhook"
+//     },
+//     "name": "hw",
+//     "privacy": "private",
+//     "version": "RLICVYSR"
+//   }
+// },
+// "oauth_client_id": "1b9f9174-a01f-40d1-9e4b-415e405c5b5b",
+// "webhook_id": 16080298
+// }
+
+// HipchatPostData is a struct for the data that is sent
+//   When the slash command is triggered
+// Only need Room Name from the POST request
+type HipchatPostData struct {
+	Event string `json:"event"`
+	Item  item   `json:"item"`
+}
+
+type item struct {
+	Room room `json:"room"`
+}
+
+type room struct {
+	Name string `json:"name"`
+}
+
+// ParsedHipchatReq simply parses the POST Req JSON into something useful
+func ParseHipchatReq(data []byte) (HipchatPostData, error) {
+	var parsedReq HipchatPostData
+	err := json.Unmarshal(data, &parsedReq)
+	if err != nil {
+		return HipchatPostData{}, err
+	}
+	return parsedReq, nil
+}
+
+// HipchatNotification sends Room Notification Message
+func HipchatNotification() error {
+	hc_auth := os.Getenv("HIPCHAT_API_TOKEN")
+	c := hipchat.NewClient(hc_auth)
+	notifMsg := &hipchat.NotificationRequest{Message: "Testing"}
+	_, err := c.Room.Notification("hw", notifMsg)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/hipchatAPI/hipchatAPI_test.go
+++ b/hipchatAPI/hipchatAPI_test.go
@@ -1,17 +1,84 @@
 package hipchatAPI
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
-var dummyPostBody = []byte(`{"event": "room_message", "item": {"message": {"date": "2017-01-28T18:56:22.407746+00:00", "from": {"id": 123456, "links": {"self": "https://api.hipchat.com/v2/user/123456"}, "mention_name": "007", "name": "James Bond", "version": "T6JP69OQ"}, "id": "aaaaaa-bbbbbb-cccccc-eeeeee-gggggg", "mentions": [], "message": "/meetspace", "type": "message"}, "room": {"id": 333333, "is_archived": false, "links": {"members": "https://api.hipchat.com/v2/room/333333/member", "participants": "https://api.hipchat.com/v2/room/333333/participant", "self": "https://api.hipchat.com/v2/room/333333", "webhooks": "https://api.hipchat.com/v2/room/333333/webhook"}, "name": "test", "privacy": "private", "version": "RLICCCSR"}}, "oauth_client_id": "1234-5678-abcd-efgh", "webhook_id": 12345678}`)
+var dummyPostBodyHelper = []byte(`{"event": "room_message", "item": {"message": {"date": "2017-01-28T18:56:22.407746+00:00", "from": {"id": 123456, "links": {"self": "https://api.hipchat.com/v2/user/123456"}, "mention_name": "007", "name": "James Bond", "version": "T6JP69OQ"}, "id": "aaaaaa-bbbbbb-cccccc-eeeeee-gggggg", "mentions": [], "message": "/meetspace", "type": "message"}, "room": {"id": 333333, "is_archived": false, "links": {"members": "https://api.hipchat.com/v2/room/333333/member", "participants": "https://api.hipchat.com/v2/room/333333/participant", "self": "https://api.hipchat.com/v2/room/333333", "webhooks": "https://api.hipchat.com/v2/room/333333/webhook"}, "name": "test", "privacy": "private", "version": "RLICCCSR"}}, "oauth_client_id": "1234-5678-abcd-efgh", "webhook_id": 12345678}`)
+
+var dummyPostBodyStatus = []byte(`{"event": "room_message", "item": {"message": {"date": ",2017-01-28T18:56:22.407746+00:00", "from": {"id": 123456, "links": {"self": "https://api.hipchat.com/v2/user/123456"}, "mention_name": "007", "name": "James Bond", "version": "T6JP69OQ"}, "id": "aaaaaa-bbbbbb-cccccc-eeeeee-gggggg", "mentions": [], "message": "/meetspace core", "type": "message"}, "room": {"id": 333333, "is_archived": false, "links": {"members": "https://api.hipchat.com/v2/room/333333/member", "participants": "https://api.hipchat.com/v2/room/333333/participant", "self": "https://api.hipchat.com/v2/room/333333", "webhooks": "https://api.hipchat.com/v2/room/333333/webhook"}, "name": "test", "privacy": "private", "version": "RLICCCSR"}}, "oauth_client_id": "1234-5678-abcd-efgh", "webhook_id": 12345678}`)
+
+var dummyPostBodyStatus = []byte(`{"event": "room_message", "item": {"message": {"date": ",2017-01-28T18:56:22.407746+00:00", "from": {"id": 123456, "links": {"self": "https://api.hipchat.com/v2/user/123456"}, "mention_name": "007", "name": "James Bond", "version": "T6JP69OQ"}, "id": "aaaaaa-bbbbbb-cccccc-eeeeee-gggggg", "mentions": [], "message": "/meetspace dev", "type": "message"}, "room": {"id": 333333, "is_archived": false, "links": {"members": "https://api.hipchat.com/v2/room/333333/member", "participants": "https://api.hipchat.com/v2/room/333333/participant", "self": "https://api.hipchat.com/v2/room/333333", "webhooks": "https://api.hipchat.com/v2/room/333333/webhook"}, "name": "test", "privacy": "private", "version": "RLICCCSR"}}, "oauth_client_id": "1234-5678-abcd-efgh", "webhook_id": 12345678}`)
+
+// init is being used here to set required env's before test execution
+func init() {
+	os.Setenv("MEETSPACEBOT_TEST", "true")
+	os.Setenv("MEETSPACEBOT_TEAM", "funtimes")
+}
 
 func TestParsedHipchatReq(t *testing.T) {
-	parsedPost, err := ParseHipchatReq(dummyPostBody)
+	parsedPost, err := ParseHipchatReq(dummyPostBodyHelper)
 	if err != nil {
 		t.Errorf("ParseHipchatReq() Error: %s", err)
 	}
 
-	// At the moment I only care about the Room Name
 	if parsedPost.Item.Room.Name != "test" {
 		t.Errorf("Expected: 'test' | Got: '%s'", parsedPost.Item.Room.Name)
+	}
+}
+
+// TestCoreTeamMessage checks hipchat.NotificationRequest.Message
+//  is correct
+func TestCoreRoomMessage(t *testing.T) {
+	expected := `Click here to join call <a href="https://meetspaceapp.com/funtimes/core">Funtimes Core Team</a>`
+	parsed, err := ParseHipchatReq(dummyPostBodyStatus)
+	if err != nil {
+		t.Errorf("ParseHipchatReq() Error: %s", err)
+	}
+
+	got, err := HipchatNotification(parsed, os.Getenv("MEETSPACEBOT_TEST"))
+	if err != nil {
+		t.Errorf("HipchatNotification() Error: %s", err)
+	}
+
+	if got != expected {
+		t.Errorf("Expected: '%s' | Got: '%s'", expected, got)
+	}
+}
+
+// TestDevTeamMessage checks hipchat.NotificationRequest.Message
+//  is correct
+func TestCoreRoomMessage(t *testing.T) {
+	expected := `Click here to join call <a href="https://meetspaceapp.com/funtimes/dev">Funtimes Dev Team</a>`
+	parsed, err := ParseHipchatReq(dummyPostBodyStatus)
+	if err != nil {
+		t.Errorf("ParseHipchatReq() Error: %s", err)
+	}
+
+	got, err := HipchatNotification(parsed, os.Getenv("MEETSPACEBOT_TEST"))
+	if err != nil {
+		t.Errorf("HipchatNotification() Error: %s", err)
+	}
+
+	if got != expected {
+		t.Errorf("Expected: '%s' | Got: '%s'", expected, got)
+	}
+}
+
+func TestHelpMessage(t *testing.T) {
+	expected := "<p><strong>Usage:</strong><br><code>/meetspace core # start core team call</code><br><code>/meetspace dev  # start dev team call</code></p>"
+	parsed, err := ParseHipchatReq(dummyPostBodyHelper)
+	if err != nil {
+		t.Errorf("ParseHipchatReq() Error: %s", err)
+	}
+
+	got, err := HipchatNotification(parsed, os.Getenv("MEETSPACEBOT_TEST"))
+	if err != nil {
+		t.Errorf("HipchatNotification() Error: %s", err)
+	}
+
+	if got != expected {
+		t.Errorf("Expected: '%s' | Got: '%s'", expected, got)
 	}
 }

--- a/hipchatAPI/hipchatAPI_test.go
+++ b/hipchatAPI/hipchatAPI_test.go
@@ -1,0 +1,17 @@
+package hipchatAPI
+
+import "testing"
+
+var dummyPostBody = []byte(`{"event": "room_message", "item": {"message": {"date": "2017-01-28T18:56:22.407746+00:00", "from": {"id": 123456, "links": {"self": "https://api.hipchat.com/v2/user/123456"}, "mention_name": "007", "name": "James Bond", "version": "T6JP69OQ"}, "id": "aaaaaa-bbbbbb-cccccc-eeeeee-gggggg", "mentions": [], "message": "/meetspace", "type": "message"}, "room": {"id": 333333, "is_archived": false, "links": {"members": "https://api.hipchat.com/v2/room/333333/member", "participants": "https://api.hipchat.com/v2/room/333333/participant", "self": "https://api.hipchat.com/v2/room/333333", "webhooks": "https://api.hipchat.com/v2/room/333333/webhook"}, "name": "test", "privacy": "private", "version": "RLICCCSR"}}, "oauth_client_id": "1234-5678-abcd-efgh", "webhook_id": 12345678}`)
+
+func TestParsedHipchatReq(t *testing.T) {
+	parsedPost, err := ParseHipchatReq(dummyPostBody)
+	if err != nil {
+		t.Errorf("ParseHipchatReq() Error: %s", err)
+	}
+
+	// At the moment I only care about the Room Name
+	if parsedPost.Item.Room.Name != "test" {
+		t.Errorf("Expected: 'test' | Got: '%s'", parsedPost.Item.Room.Name)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,29 +1,9 @@
 package main
 
 import (
-	"fmt"
-	"io/ioutil"
-	"log"
-	"net/http"
+	"github.com/davyj0nes/meetspaceBot/router"
 )
 
-// {
-// "color": "green",
-// "message": "It's going to be sunny tomorrow! (yey)",
-// "notify": false,
-// "message_format": "text"
-// }
-func testHandler(w http.ResponseWriter, req *http.Request) {
-	if req.URL.Path != "/" {
-		http.NotFound(w, req)
-		return
-	}
-	reqBody, _ := ioutil.ReadAll(req.Body)
-	fmt.Println(string(reqBody))
-	fmt.Fprintf(w, "Hey")
-}
-
 func main() {
-	http.HandleFunc("/", testHandler)
-	log.Fatal(http.ListenAndServe("localhost:8080", nil))
+	router.Router()
 }

--- a/meetspaceAPI/meetspaceAPI.go
+++ b/meetspaceAPI/meetspaceAPI.go
@@ -1,12 +1,15 @@
 package meetspaceAPI
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 )
 
-type meetspaceData struct {
+// MeetspaceData defines API response from meetspace
+type MeetspaceData struct {
 	Id    string `json:"id"`
 	Name  string `json:"name"`
 	Url   string `json:"url"`
@@ -28,14 +31,27 @@ type participant struct {
 	Avatarurl string `json:"avatar-url"`
 }
 
-func MeetspaceCall(url string) ([]byte, error) {
-	reqUrl := url + "/i/api/v0/status"
-	res, err := http.Get(reqUrl)
+// MeetspaceCall makes API call
+// Am hardcoding the API version at v0 to stop breaking changes in future
+//  major version releases
+func MeetspaceCall(url string, endpoint string) ([]byte, error) {
+	client := &http.Client{}
+	reqUrl := url + "/i/api/v0/" + endpoint
+	req, err := http.NewRequest("GET", reqUrl, nil)
 	if err != nil {
 		return nil, err
 	}
+
+	// Using Env to abstract keys to from app
+	token := os.Getenv("MEETSPACE_API_TOKEN")
+	req.Header.Set("Authorization", token)
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("server didn't respond with 200 OK | Got: %s", res.Status)
+		return nil, fmt.Errorf("Server Replied with: %s", res.Status)
 	}
 	data, err := ioutil.ReadAll(res.Body)
 	defer res.Body.Close()
@@ -45,6 +61,13 @@ func MeetspaceCall(url string) ([]byte, error) {
 	return data, nil
 }
 
-func MeetspaceFormat(data []byte) error {
-	return nil
+// MeetspaceFormat parses API JSON response into MeetspaceData struct
+//  for use in other parts of the app
+func MeetspaceFormat(data []byte) (MeetspaceData, error) {
+	var formattedData MeetspaceData
+	err := json.Unmarshal(data, &formattedData)
+	if err != nil {
+		return MeetspaceData{}, err
+	}
+	return formattedData, nil
 }

--- a/meetspaceAPI/meetspaceAPI_test.go
+++ b/meetspaceAPI/meetspaceAPI_test.go
@@ -3,12 +3,23 @@ package meetspaceAPI
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 )
 
-func TestMeetspaceRequest(t *testing.T) {
-	mockStatus := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+var dummyData []byte = []byte(`{"id":"1001","name":"Testy","url":"https://meetspaceapp.com/testy","rooms":[{"id":"aabb1234","name":"calltime","url":"https://meetspaceapp.com/testy/calltime","public":"\u003ctrue","participants":[{"id":"aabb1234bbaa4321","name":"jamesbond","email":"doubleoh@mod.gov","avatar-url":"https://pbs.twimg.com/profile_images/522485330771845120/gK0H2djd_400x400.jpeg"}]}]}`)
+
+// init is being used here to set required env's before test execution
+func init() {
+	os.Setenv("MEETSPACE_API_TOKEN", "123456789")
+}
+
+// testServerHelper abstracts repeated code that is used to mock Meetspace API
+func testServerHelper(t *testing.T) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(dummyData)
 
 		if req.Method != "GET" {
 			t.Errorf("Expected 'GET' | Got '%s'", req.Method)
@@ -17,35 +28,67 @@ func TestMeetspaceRequest(t *testing.T) {
 		if req.URL.EscapedPath() != "/i/api/v0/status" {
 			t.Errorf("Expected '/i/api/v0/status' | Got '%s'", req.URL.EscapedPath())
 		}
-	})
 
-	ts := httptest.NewServer(mockStatus)
+		if req.Header["Authorization"][0] != "123456789" {
+			t.Errorf("Expected '123456789' | Got '%s'", req.Header["Authorization"][0])
+		}
+	})
+}
+
+// TestMeetSpaceRequest checks that request to API is correct
+// Used to mock out Meetspace API
+func TestMeetspaceRequest(t *testing.T) {
+	mockHandler := testServerHelper(t)
+	ts := httptest.NewServer(mockHandler)
 	defer ts.Close()
 
 	reqUrl := ts.URL
-	_, err := MeetspaceCall(reqUrl)
+	_, err := MeetspaceCall(reqUrl, "status")
 	if err != nil {
 		t.Errorf("MeetspaceCall() returned error: %s", err)
 	}
 }
 
+// TestMeetspaceResponse checks that byte slice from API matches dummyData
+// Used to mock out Meetspace API
 func TestMeetspaceResponse(t *testing.T) {
-	dummyData := []byte(`{"id":"1001","name":"Testy","url":"https://meetspaceapp.com/testy","rooms":[{"id":"aabb1234","name":"calltime","url":"https://meetspaceapp.com/testy/calltime","public":"\u003ctrue","participants":[{"id":"aabb1234bbaa4321","name":"jamesbond","email":"doubleoh@mod.gov","avatar-url":"https://pbs.twimg.com/profile_images/522485330771845120/gK0H2djd_400x400.jpeg"}]}]}`)
-	mockStatus := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Header().Set("Content-Type", "application/json")
-		w.Write(dummyData)
-	})
-
-	ts := httptest.NewServer(mockStatus)
+	mockHandler := testServerHelper(t)
+	ts := httptest.NewServer(mockHandler)
 	defer ts.Close()
 
 	reqUrl := ts.URL
-	data, err := MeetspaceCall(reqUrl)
+	resData, err := MeetspaceCall(reqUrl, "status")
 	if err != nil {
 		t.Errorf("MeetspaceCall() returned error: %s", err)
 	}
-	if string(data) != string(dummyData) {
-		t.Errorf("Expected: '%s' | Got: '%s'", dummyData, data)
+	if string(resData) != string(dummyData) {
+		t.Errorf("Expected: '%s' | Got: '%s'", dummyData, resData)
+	}
+}
+
+// TestMeetspaceFormat checks that API response converts correctly into MeetspaceData struct
+func TestMeetspaceFormat(t *testing.T) {
+	mockHandler := testServerHelper(t)
+	ts := httptest.NewServer(mockHandler)
+	defer ts.Close()
+
+	reqUrl := ts.URL
+	resData, err := MeetspaceCall(reqUrl, "status")
+	if err != nil {
+		t.Errorf("MeetspaceCall() returned error: %s", err)
+	}
+
+	wrangledData, err := MeetspaceFormat(resData)
+	if err != nil {
+		t.Errorf("MeetspaceFormat() returned error: %s", err)
+	}
+	if wrangledData.Name != "Testy" {
+		t.Errorf("Expected: '%s' | Got: '%s'", "Testy", wrangledData.Name)
+	}
+	if wrangledData.Rooms[0].Name != "calltime" {
+		t.Errorf("Expected: '%s' | Got: '%s'", "calltime", wrangledData.Rooms[0].Name)
+	}
+	if wrangledData.Rooms[0].Participants[0].Name != "jamesbond" {
+		t.Errorf("Expected: '%s' | Got: '%s'", "jamesbond", wrangledData.Rooms[0].Participants[0].Name)
 	}
 }

--- a/router/router.go
+++ b/router/router.go
@@ -1,8 +1,10 @@
 package router
 
 import (
+	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/davyj0nes/meetspacebot/hipchatAPI"
 )
@@ -11,25 +13,30 @@ func requestLogger(req *http.Request) {
 	log.Printf("%s | %s || %s => %s || %s", req.Method, req.URL.Path, req.RemoteAddr, req.Host, req.Header.Get("User-Agent"))
 }
 
-func Router() {
-	http.HandleFunc("/api/v0/hipchat", HipchatHandler)
-	http.HandleFunc("/api/v0/slack", SlackHandler)
-	log.Fatal(http.ListenAndServe(":8081", nil))
+func Router() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v0/hipchat", HipchatHandler)
+	// mux.HandleFunc("/api/v0/slack", SlackHandler)
+	log.Fatal(http.ListenAndServe(":8081", mux))
+	return mux
 }
 
 func HipchatHandler(w http.ResponseWriter, req *http.Request) {
 	requestLogger(req)
-	// reqBody, _ := ioutil.ReadAll(req.Body)
-	// log.Printf("Body: '%s'", string(reqBody))
-	w.Header().Set("Content-Type", "application/json")
-	err := hipchatAPI.HipchatNotification()
-	if err != nil {
-		log.Fatal(err)
-	}
-}
 
-func SlackHandler(w http.ResponseWriter, req *http.Request) {
-	requestLogger(req)
+	reqBody, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		log.Fatal("Couldn't read Body of Request", err)
+	}
+
+	parsed, err := hipchatAPI.ParseHipchatReq(reqBody)
+	if err != nil {
+		log.Fatal("Hipchat | Error parsing Body of Request: ", err)
+	}
+
+	_, er := hipchatAPI.HipchatNotification(parsed, os.Getenv("MEETSPACEBOT_TEST"))
+	if er != nil {
+		log.Fatal("Hipchat | Error Sending Request: ", er)
+	}
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte("hey"))
 }

--- a/router/router.go
+++ b/router/router.go
@@ -1,0 +1,35 @@
+package router
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/davyj0nes/meetspacebot/hipchatAPI"
+)
+
+func requestLogger(req *http.Request) {
+	log.Printf("%s | %s || %s => %s || %s", req.Method, req.URL.Path, req.RemoteAddr, req.Host, req.Header.Get("User-Agent"))
+}
+
+func Router() {
+	http.HandleFunc("/api/v0/hipchat", HipchatHandler)
+	http.HandleFunc("/api/v0/slack", SlackHandler)
+	log.Fatal(http.ListenAndServe(":8081", nil))
+}
+
+func HipchatHandler(w http.ResponseWriter, req *http.Request) {
+	requestLogger(req)
+	// reqBody, _ := ioutil.ReadAll(req.Body)
+	// log.Printf("Body: '%s'", string(reqBody))
+	w.Header().Set("Content-Type", "application/json")
+	err := hipchatAPI.HipchatNotification()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func SlackHandler(w http.ResponseWriter, req *http.Request) {
+	requestLogger(req)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte("hey"))
+}

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -2,24 +2,48 @@ package router
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 )
+
+var hcTestData = strings.NewReader(`{"event": "room_message", "item": {"message": {"date": "2017-01-28T18:56:22.407746+00:00", "from": {"id": 123456, "links": {"self": "https://api.hipchat.com/v2/user/123456"}, "mention_name": "007", "name": "James Bond", "version": "T6JP69OQ"}, "id": "aaaaaa-bbbbbb-cccccc-eeeeee-gggggg", "mentions": [], "message": "/meetspace", "type": "message"}, "room": {"id": 333333, "is_archived": false, "links": {"members": "https://api.hipchat.com/v2/room/333333/member", "participants": "https://api.hipchat.com/v2/room/333333/participant", "self": "https://api.hipchat.com/v2/room/333333", "webhooks": "https://api.hipchat.com/v2/room/333333/webhook"}, "name": "test", "privacy": "private", "version": "RLICCCSR"}}, "oauth_client_id": "1234-5678-abcd-efgh", "webhook_id": 12345678}`)
+
+// init is being used here to set required env's before test execution
+func init() {
+	os.Setenv("MEETSPACEBOT_TEST", "true")
+}
+
+// func TestRouter(t *testing.T) {
+//   req, err := http.NewRequest("GET", "/api/v0/hipchat", nil)
+//   if err != nil {
+//     t.Fatal(err)
+//   }
+
+//   rr := httptest.NewRecorder()
+//   handler := http.HandlerFunc(HipchatHandler)
+
+//   handler.ServeHTTP(rr, req)
+//   if status := rr.Code; status != http.StatusOK {
+//     t.Errorf("handler returned wrong status code: got %v want %v",
+//       status, http.StatusOK)
+//   }
+// }
 
 func TestHipchatHandler(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(HipchatHandler))
 	defer ts.Close()
-	reqUrl := ts.URL
-	res, err := http.Post(reqUrl, "", nil)
+
+	reqUrl := fmt.Sprintf("%s/api/v0/hipchat", ts.URL)
+
+	res, err := http.Post(reqUrl, "", hcTestData)
 	if err != nil {
 		t.Errorf("Error Posting to MeetspaceHandler:, %s", err)
 	}
-	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
-	fmt.Println(string(body))
-}
 
-func TestSlackHandler(t *testing.T) {
+	if res.StatusCode != 200 {
+		t.Errorf("Expected 200 | Got: %s", res.StatusCode)
+	}
 }

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -1,0 +1,25 @@
+package router
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHipchatHandler(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(HipchatHandler))
+	defer ts.Close()
+	reqUrl := ts.URL
+	res, err := http.Post(reqUrl, "", nil)
+	if err != nil {
+		t.Errorf("Error Posting to MeetspaceHandler:, %s", err)
+	}
+	defer res.Body.Close()
+	body, _ := ioutil.ReadAll(res.Body)
+	fmt.Println(string(body))
+}
+
+func TestSlackHandler(t *testing.T) {
+}


### PR DESCRIPTION
# Overview
- Added Hipchat URL handlers
- Very basic return functionality
- Getting strange errors when using Card message type (need to look more into)
- Not linked to meetspace API yet due to it not being available (might create demo server in next feature)
- Added router to handle hipchat POST requests
- Created deploy script to help push to production and maintain
- Using Docker for deployment with statically linked Go binary
- Updated Readme

# Problems
- Using static returns to Hipchat while awaiting Meetspace API to be available.
- Haven't found good way to test server, handlers are being tested though.
- There are some hacked together bits that look quite messy. refactor needed in future